### PR TITLE
Library create

### DIFF
--- a/src/app/components/molecules/ActionButton.js
+++ b/src/app/components/molecules/ActionButton.js
@@ -84,7 +84,7 @@ const ActionButton = ({ type, onPress }) => {
             </Text>
           </>
         )
-      case 'moveLibrary':
+      case 'ok':
         return (
           <>
             <Text>Ok</Text>

--- a/src/app/components/organisms/MainPage.js
+++ b/src/app/components/organisms/MainPage.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useContext } from "react";
-import { StyleSheet, View, Alert, Animated } from "react-native";
+import { StyleSheet, View, Alert, Animated, Keyboard } from "react-native";
 
 import { getInitialLocation, returnSearchLocation, } from "../../services/location";
 import { updateDB_AddLibrary, librariesWithin10km, updateDB_MoveLibrary, } from "../../services/LibraryServices";
@@ -103,6 +103,7 @@ const MainPage = ({ navigation }) => {
     } else {
       Alert.alert("please enter valid search criteria");
     }
+    Keyboard.dismiss();
     return;
   };
 
@@ -172,6 +173,7 @@ const MainPage = ({ navigation }) => {
     setNewMarker(false);
     switchInputsToShowSearchBox();
     setNewLibraryName("");
+    Keyboard.dismiss();
     selectLibrary();
     return;
   };
@@ -180,6 +182,7 @@ const MainPage = ({ navigation }) => {
     switchInputsToShowSearchBox();
     setNewMarker(false);
     setNewLibraryName("");
+    Keyboard.dismiss();
     return;
   };
 
@@ -203,11 +206,13 @@ const MainPage = ({ navigation }) => {
     );
 
     if (updatedLibraryInfo) updateLibrary(updatedLibraryInfo, selectedLibraryInfo.id);
+    Keyboard.dismiss();
     return;
   };
 
   const cancelNewLocation = () => {
     movingLibraryFlagToggle(false);
+    Keyboard.dismiss();
     return;
   };
   
@@ -216,7 +221,7 @@ const MainPage = ({ navigation }) => {
   /*************************************************/
 
   return (
-    <View style={styles.container} testID={'main'}>
+    <View style={styles.container} testID={"main"}>
       {Object.values(lastKnownLocation).length > 0 && (
         <Map
           region={lastKnownLocation}
@@ -274,11 +279,11 @@ const MainPage = ({ navigation }) => {
         onSubmitEditing={createNewLibrary}
         placeholder={`Enter Your New Library's Name`}
         placeholderTextColor={"white"}
-        children={<PressableTextCancel onPress={cancelNewLibrary} />}
+        // children={<PressableTextCancel onPress={cancelNewLibrary} />}
         value={newLibraryName}
       />
 
-      {!movingFlag ? (
+      {!movingFlag && !newMarker && (
         <ActionBar
           children={
             <>
@@ -288,12 +293,23 @@ const MainPage = ({ navigation }) => {
             </>
           }
         />
-      ) : (
+      )}
+      {movingFlag && !newMarker && (
         <ActionBar
           children={
             <>
-              <ActionButton type={"moveLibrary"} onPress={acceptNewLocation} />
+              <ActionButton type={"ok"} onPress={acceptNewLocation} />
               <PressableTextCancel onPress={cancelNewLocation} />
+            </>
+          }
+        />
+      )}
+      {newMarker && !movingFlag && (
+        <ActionBar
+          children={
+            <>
+              <ActionButton type={"ok"} onPress={createNewLibrary} />
+              <PressableTextCancel onPress={cancelNewLibrary} />
             </>
           }
         />

--- a/src/app/components/organisms/MainPage.js
+++ b/src/app/components/organisms/MainPage.js
@@ -126,11 +126,11 @@ const MainPage = ({ navigation }) => {
         [
           {
             text: "OK",
-            onPress: () => switchInputsToShowLibraryNameBox(),
           },
         ]
       );
     }
+    switchInputsToShowLibraryNameBox();
     setCreationAlertFlag(true);
     setNewMarker(true);
     return;
@@ -279,7 +279,6 @@ const MainPage = ({ navigation }) => {
         onSubmitEditing={createNewLibrary}
         placeholder={`Enter Your New Library's Name`}
         placeholderTextColor={"white"}
-        // children={<PressableTextCancel onPress={cancelNewLibrary} />}
         value={newLibraryName}
       />
 


### PR DESCRIPTION
change action bar options while adding a new library as to not make it confusing for the user during the workflow.  There was a bug that after dismissing the instructions on how to create a new library, that if the user tried to create another new library, the new name input field would not appear.